### PR TITLE
Add OracleLinux support

### DIFF
--- a/files/bash/os_test.sh
+++ b/files/bash/os_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -e /etc/os-release ]; then
-  export OS_RELEASE=$(sed -n -e "/^ID=/p" /etc/os-release | sed -e 's~\(.*\)=\(.*\)~\U\2~g' -e 's~"~~g')
+  export OS_RELEASE=$(sed -n -e "/^ID=/p" /etc/os-release | sed -e 's~\(.*\)=\(.*\)~\U\2~g' -e 's~[" ]~~g')
 else
 # fall back to older methods for OS that do not use systemd
   export OS_TEST_DEB=$(lsb_release -a 2> /dev/null | grep Distributor | awk '{print $3}')

--- a/tasks/available_updates_linux.sh
+++ b/tasks/available_updates_linux.sh
@@ -5,7 +5,7 @@ source "${PT__installdir}/patching/files/bash/os_test.sh"
 
 case $OS_RELEASE in
 ################################################################################  
-  RHEL | CENTOS | FEDORA)
+  RHEL | CENTOS | FEDORA | OL)
     # RedHat variant
     source "${PT__installdir}/patching/files/bash/available_updates_rh.sh"
     ;;

--- a/tasks/cache_update_linux.sh
+++ b/tasks/cache_update_linux.sh
@@ -11,7 +11,7 @@ source "${PT__installdir}/patching/files/bash/os_test.sh"
 
 case $OS_RELEASE in
 ################################################################################
-  RHEL | CENTOS | FEDORA)
+  RHEL | CENTOS | FEDORA | OL)
     # RedHat variant
     # update yum cache
     OUTPUT=$(yum clean expire-cache 2>&1)

--- a/tasks/reboot_required_linux.sh
+++ b/tasks/reboot_required_linux.sh
@@ -8,7 +8,7 @@ export REBOOT_REQUIRED="false"
 
 case $OS_RELEASE in
 ################################################################################  
-  RHEL | CENTOS | FEDORA)
+  RHEL | CENTOS | FEDORA | OL)
     # RedHat variant
     source "${PT__installdir}/patching/files/bash/reboot_required_rh.sh"
     ;;

--- a/tasks/update_linux.sh
+++ b/tasks/update_linux.sh
@@ -24,7 +24,7 @@ STATUS=0
 
 case $OS_RELEASE in
 ################################################################################  
-  RHEL | CENTOS | FEDORA)
+  RHEL | CENTOS | FEDORA | OL)
     # RedHat variant
     source "${PT__installdir}/patching/files/bash/update_rh.sh"
     STATUS=$?


### PR DESCRIPTION
Correctly detect/parse OS_RELEASE on OracleLinux and include OL
as a RHEL-compatible OS.